### PR TITLE
lib-lopez: fix test compilation

### DIFF
--- a/lib-lopez/src/directives/parse.rs
+++ b/lib-lopez/src/directives/parse.rs
@@ -348,7 +348,7 @@ fn flag_directive(directive_tags: &'static [&'static str]) -> impl Fn(&str) -> I
 
 #[test]
 fn flag_directive_test() {
-    assert_eq!(string_directive(&["foo"])("foo;"), Ok(("", ())));
+    assert_eq!(flag_directive(&["foo"])("foo;"), Ok(("", ())));
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Well, I've tried running the tests locally, and I got a compilation error:

```
   Compiling reqwest v0.10.7
   Compiling lib-lopez v0.1.0 (/home/otaviopace/lopez/lib-lopez)
   Compiling postgres-lopez v0.1.0 (/home/otaviopace/lopez/postgres-lopez)
error[E0308]: mismatched types
   --> lib-lopez/src/directives/parse.rs:351:5
    |
351 |     assert_eq!(string_directive(&["foo"])("foo;"), Ok(("", ())));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `std::string::String`, found `()`
    |
    = note: expected enum `std::result::Result<(&str, std::string::String), nom::Err<(&str, nom::error::ErrorKind)>>`
               found enum `std::result::Result<(&str, ()), _>`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `lib-lopez`.

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: build failed
```
Or as a image:
![Screenshot from 2020-08-22 16-34-57](https://user-images.githubusercontent.com/15306309/90964322-e4511300-e495-11ea-82d4-bdddda90b12b.png)


The error was that a test was calling the wrong function, so it was a simple typo.